### PR TITLE
이메일 요청하는 로직을 추가한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,16 @@ configurations {
 	}
 }
 
+ext {
+	set('springCloudVersion', "2022.0.3")
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
+}
+
 repositories {
 	mavenCentral()
 }
@@ -30,6 +40,10 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.projectreactor:reactor-test'
+
+	// feign
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	implementation 'io.github.openfeign:feign-gson:12.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/wooteco/member/MemberApplication.java
+++ b/src/main/java/com/wooteco/member/MemberApplication.java
@@ -1,9 +1,14 @@
 package com.wooteco.member;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.cloud.openfeign.FeignAutoConfiguration;
 
+@EnableFeignClients
 @SpringBootApplication
+@ImportAutoConfiguration({FeignAutoConfiguration.class})
 public class MemberApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/wooteco/member/business/MemberService.java
+++ b/src/main/java/com/wooteco/member/business/MemberService.java
@@ -1,5 +1,9 @@
 package com.wooteco.member.business;
 
+import com.wooteco.member.business.client.MailOpenFeign;
+import com.wooteco.member.business.dto.MailSendRequest;
+import com.wooteco.member.business.dto.MemberCreateRequest;
+import com.wooteco.member.domain.Member;
 import com.wooteco.member.domain.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -9,9 +13,11 @@ import org.springframework.stereotype.Service;
 public class MemberService {
 
     private final MemberRepository memberRepository;
-
+    private final MailOpenFeign mailOpenFeign;
 
     public Long createMember(MemberCreateRequest request) {
-        return memberRepository.save(request.toMember()).getId();
+        Member member = memberRepository.save(request.toMember());
+        mailOpenFeign.sendMail(new MailSendRequest(member.getEmail(), "만나서", "반갑습니다"));
+        return member.getId();
     }
 }

--- a/src/main/java/com/wooteco/member/business/client/MailOpenFeign.java
+++ b/src/main/java/com/wooteco/member/business/client/MailOpenFeign.java
@@ -5,7 +5,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@FeignClient(name = "MailOpenFeign", url = "${mail.server.url}")
+@FeignClient(name = "toy-toy-mail", url = "${mail.server.url}")
 public interface MailOpenFeign {
 
     @PostMapping("/mail/send")

--- a/src/main/java/com/wooteco/member/business/client/MailOpenFeign.java
+++ b/src/main/java/com/wooteco/member/business/client/MailOpenFeign.java
@@ -1,0 +1,13 @@
+package com.wooteco.member.business.client;
+
+import com.wooteco.member.business.dto.MailSendRequest;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "MailOpenFeign", url = "${mail.server.url}")
+public interface MailOpenFeign {
+
+    @PostMapping("/mail/send")
+    void sendMail(@RequestBody MailSendRequest mailSendRequest);
+}

--- a/src/main/java/com/wooteco/member/business/dto/MailSendRequest.java
+++ b/src/main/java/com/wooteco/member/business/dto/MailSendRequest.java
@@ -1,0 +1,19 @@
+package com.wooteco.member.business.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MailSendRequest {
+
+    private String toAddress;
+    private String title;
+    private String content;
+
+    public MailSendRequest(String email, String title, String content) {
+        this.toAddress = email;
+        this.title = title;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/wooteco/member/business/dto/MemberCreateRequest.java
+++ b/src/main/java/com/wooteco/member/business/dto/MemberCreateRequest.java
@@ -1,4 +1,4 @@
-package com.wooteco.member.business;
+package com.wooteco.member.business.dto;
 
 import com.wooteco.member.domain.Member;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/wooteco/member/config/OpenFeignConfig.java
+++ b/src/main/java/com/wooteco/member/config/OpenFeignConfig.java
@@ -1,0 +1,26 @@
+package com.wooteco.member.config;
+
+import static feign.Logger.Level.BASIC;
+
+import feign.Logger;
+import feign.Retryer;
+import java.util.concurrent.TimeUnit;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients("com.wooteco.member")
+public class OpenFeignConfig {
+
+    @Bean
+    Logger.Level feignLoggerLevel() {
+        return BASIC;
+    }
+
+    @Bean
+    Retryer.Default retryer() {
+        // 0.1초의 간격으로 시작해 최대 3초의 간격으로 점점 증가하며, 최대5번 재시도한다.
+        return new Retryer.Default(100L, TimeUnit.SECONDS.toMillis(3L), 5);
+    }
+}

--- a/src/main/java/com/wooteco/member/presentation/MemberController.java
+++ b/src/main/java/com/wooteco/member/presentation/MemberController.java
@@ -1,10 +1,8 @@
 package com.wooteco.member.presentation;
 
-import com.wooteco.member.business.MemberCreateRequest;
+import com.wooteco.member.business.dto.MemberCreateRequest;
 import com.wooteco.member.business.MemberService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatusCode;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,4 @@
 spring.h2.console.enabled=true
 spring.jpa.hibernate.ddl-auto=create
+mail.server.url=${MAIL_SERVER_URL}
+spring.main.allow-bean-definition-overriding=true


### PR DESCRIPTION
## 세부 사항

- 멤버를 생성한 뒤 이메일을 보내는 요청을 보낸다.

## 고려한 사항

### RestTemplate

- 대중적인 api 요청 라이브러리입니다. 우선적으로 고려하였지만, 요청을 보내고 응답 받는 데에 불편함이 많고 확장적이지 못해 보류하였습니다.

### Feign

- Netflix 에서 만든 오픈소스 api 요청 라이브러리입니다. 간단하게 학습하면 쉽게 사용할 수 있습니다. 요청을 보내고 응답 받을 때 기존의 api 처럼 이용할 수 있어서 편리합니다. 또한 인터페이스로 제공하여 확장성이 뛰어납니다. 그래서 feign 을 사용하였습니다.

## 에러 핸들링

1. 오버라이딩 문제

`The bean 'MailOpenFeign.FeignClientSpecification' could not be registered. A bean with that name has already been defined and overriding is disabled.`

빈이 중복되어 오버라이딩 문제가 발생하였습니다. 그래서 오버라이딩을 허용하는 설정을 추가하였습니다.

2. auto configuration 문제

`Consider defining a bean of type 'org.springframework.cloud.openfeign.FeignContext' in your configuration.`

스프링부트 3.0.0 이후부터 spring cloud 에 대해 자동 설정 문제가 발생한다고 합니다. 그래서 `@ImportAutoConfiguration({FeignAutoConfiguration.class})` 어노테이션을 추가하여 명시하였습니다.

3. 스프링부트 클라우드 버전 문제

`Receiver class org.springframework.cloud.openfeign.support.SpringDecoder$FeignResponseAdapter does not define or inherit an implementation of the resolved method 'abstract org.springframework.http.HttpStatusCode getStatusCode()' of interface org.springframework.http.client.ClientHttpResponse.`

스프링부트 3.0.X -> 스프링 클라우드 2022.0.1
스프링부트 3.1.X -> 스프링 클라우드 2022.0.3

버전 문제가 심각하네요
